### PR TITLE
Update name and email due to namechange

### DIFF
--- a/members.json
+++ b/members.json
@@ -143,10 +143,10 @@
     }
   },
   {
-    "name": "Elis Axelsson",
+    "name": "Elis Hirwing",
     "github": "etu",
     "optionals": {
-      "email": "elis.axelsson@gmail.com",
+      "email": "elis@hirwing.se",
       "keybase": "etu"
     }
   },


### PR DESCRIPTION
This commit is signed with the same GPG-Key as the commit used to add me initially in this commit 518ca21d13a8dcd69248ea15252996058f6f0fab